### PR TITLE
fix(version): sso version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "mysql2": "^3.15.3",
         "reflect-metadata": "^0.2.2",
         "sharp": "^0.34.5",
-        "sso-bridge": "github:ETML-INF/SSO-Bridge"
+        "sso-bridge": "github:ETML-INF/SSO-Bridge#1.0.1"
       },
       "devDependencies": {
         "@adonisjs/assembler": "^7.8.2",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "mysql2": "^3.15.3",
     "reflect-metadata": "^0.2.2",
     "sharp": "^0.34.5",
-    "sso-bridge": "github:ETML-INF/SSO-Bridge"
+    "sso-bridge": "github:ETML-INF/SSO-Bridge#1.0.1"
   },
   "hotHook": {
     "boundaries": [


### PR DESCRIPTION
[1][DONE]
This pull request updates the `sso-bridge` dependency in the `package.json` file to use a specific version from the repository. This change ensures that the project consistently uses version `1.0.1` of `sso-bridge`, which can help with dependency management and reproducibility.

Dependency management:

* Updated the `sso-bridge` dependency to point to `github:ETML-INF/SSO-Bridge#1.0.1` instead of the default branch, ensuring the project uses a fixed version.
force sable version